### PR TITLE
【Fixed】Issue#2

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -16,9 +16,14 @@ class AssignsController < ApplicationController
 
   def destroy
     assign = Assign.find(params[:id])
-    destroy_message = assign_destroy(assign, assign.user)
-
-    redirect_to team_url(params[:team_id]), notice: destroy_message
+    assigned_user = assign.user
+    # チームのオーナーまたは削除対象のユーザー本人のみ削除できるようにする
+    unless assign.team.owner == current_user || assigned_user == current_user
+      redirect_to team_url(params[:team_id]), notice: I18n.t('views.messages.cannot_delete_member')
+    return
+  end
+  destroy_message = assign_destroy(assign, assigned_user)
+  redirect_to team_url(params[:team_id]), notice: destroy_message
   end
 
   private

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -20,8 +20,8 @@ class AssignsController < ApplicationController
     # チームのオーナーまたは削除対象のユーザー本人のみ削除できるようにする
     unless assign.team.owner == current_user || assigned_user == current_user
       redirect_to team_url(params[:team_id]), notice: I18n.t('views.messages.cannot_delete_member')
-    return
-  end
+      return
+    end
   destroy_message = assign_destroy(assign, assigned_user)
   redirect_to team_url(params[:team_id]), notice: destroy_message
   end
@@ -67,7 +67,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
+  def find_team(_team_id)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,13 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    unless @team.owner == current_user
+      redirect_to @team
+    else
+      render :edit
+    end
+  end
 
   def create
     @team = Team.new(team_params)

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user.id == @team.owner.id %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if (current_user.id == assign.team.owner.id ) || ( current_user.id == assign.user.id ) %>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,2 @@
+I18n.config.available_locales = :ja
+I18n.default_locale = :ja


### PR DESCRIPTION
issues#2


- [ ] Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
- [ ] TeamのeditはTeamのリーダー（オーナー）のみができるようにすること